### PR TITLE
Remove unused assets from getAssets method

### DIFF
--- a/src/AuthUIEnhancerServiceProvider.php
+++ b/src/AuthUIEnhancerServiceProvider.php
@@ -70,8 +70,8 @@ class AuthUIEnhancerServiceProvider extends PackageServiceProvider
     protected function getAssets(): array
     {
         return [
-//            Css::make('filament-auth-ui-enhancer-styles', __DIR__ . '/../resources/dist/filament-auth-ui-enhancer.css'),
-//            Js::make('filament-auth-ui-enhancer-scripts', __DIR__ . '/../resources/dist/filament-auth-ui-enhancer.js'),
+            //            Css::make('filament-auth-ui-enhancer-styles', __DIR__ . '/../resources/dist/filament-auth-ui-enhancer.css'),
+            //            Js::make('filament-auth-ui-enhancer-scripts', __DIR__ . '/../resources/dist/filament-auth-ui-enhancer.js'),
         ];
     }
 


### PR DESCRIPTION
When installing the package, it tries to load the CSS/JS files, but there are none built, and they aren't needed for this package. So, I have commented out the loading in the app service provider.

```
ErrorException
copy('filament-auth-ui-enhancer/src/../resources/dist/filament-auth-ui-enhancer.js): Failed to open stream: No such file or directory
```